### PR TITLE
Remove eval() from codebase.

### DIFF
--- a/src/common/Pakiti.php
+++ b/src/common/Pakiti.php
@@ -75,15 +75,12 @@ final class Pakiti
      */
     public function getManager($name)
     {
-        # Get the first charactar and make it lowercase
-        $lcFirstChar = strtolower(substr($name, 0, 1));
-        $propertyName = $lcFirstChar . substr($name, 1);
-        eval("\$manager =& \$this->_$propertyName;");
-        
-        if ($manager == null) {
-            eval("\$manager = new $name(\$this);");
+        $propertyName = "_" . lcfirst($name);
+        if (!isset($this->$propertyName))
+        {
+            $this->$propertyName = new $name($this);
         }
-        return $manager;
+        return $this->$propertyName;
     }
 
     /**
@@ -91,7 +88,7 @@ final class Pakiti
      */
     public function getDao($className)
     {
-        eval("\$dao = new ${className}Dao(\$this->getManager(\"DbManager\"));");
-        return $dao;
+        $className .= "Dao"; 
+        return new $className($this->getManager("DbManager"));
     }
 }

--- a/src/modules/vds/VdsModule.php
+++ b/src/modules/vds/VdsModule.php
@@ -120,7 +120,7 @@ class VdsModule extends DefaultModule
                     # Get the filename and extension, filename represent the class name
                     $classname = preg_replace('/.php$/i', '', $file);
 
-                    eval("\$source = new $classname(\$this->getPakiti());");
+                    $source = new $classname($this->getPakiti());
 
                     # Register source if it was not registered before
                     if (!$this->isSourceRegistered($source)) {

--- a/src/modules/vds/lib/Source.php
+++ b/src/modules/vds/lib/Source.php
@@ -97,7 +97,7 @@ class Source extends VdsSource
 
                 # Get the filename and extension, filename represent the class name
                 $className = preg_replace('/.php$/i', '', $file);
-                eval("\$subSource = new $className(\$this->_pakiti);");
+                $subSource = new $className($this->_pakiti);
 
                 # Check if the module is already registered
                 if (($id = $this->_pakiti->getManager("DbManager")->queryToSingleValue("select id from VdsSubSource where type='".$this->_pakiti->getManager("DbManager")->escape($subSource->getType())."' and name='".$this->_pakiti->getManager("DbManager")->escape($subSource->getName())."'")) == null) {


### PR DESCRIPTION
Remove eval() from codebase. We can create the required objects directly rather than use eval().