### PR TITLE
Remove passing Objects around by reference

### DIFF
--- a/src/common/Acl.php
+++ b/src/common/Acl.php
@@ -40,9 +40,9 @@ class Acl
         return $this->_pakiti;
     }
 
-    public function __construct(Pakiti &$pakiti)
+    public function __construct(Pakiti $pakiti)
     {
-        $this->_pakiti = &$pakiti;
+        $this->_pakiti = $pakiti;
         if (Config::$AUTHZ_MODE != Constants::$AUTHZ_MODE_NONE) {
 
             # Get data from env variables

--- a/src/common/DefaultModule.php
+++ b/src/common/DefaultModule.php
@@ -34,9 +34,9 @@ class DefaultModule
 {
     private $_pakiti;
 
-    public function __construct(&$pakiti)
+    public function __construct($pakiti)
     {
-        $this->_pakiti =& $pakiti;
+        $this->_pakiti = $pakiti;
     }
 
     public function getPakiti()

--- a/src/dao/ArchDao.php
+++ b/src/dao/ArchDao.php
@@ -34,7 +34,7 @@ class ArchDao
 {
     private $db;
 
-    public function __construct(DbManager &$dbManager)
+    public function __construct(DbManager $dbManager)
     {
         $this->db = $dbManager;
     }
@@ -42,7 +42,7 @@ class ArchDao
     /**
      * Stores the arch in the DB
      */
-    public function create(Arch &$arch)
+    public function create(Arch $arch)
     {
         $this->db->query("insert into Arch set
             name='".$this->db->escape($arch->getName())."'");
@@ -90,7 +90,7 @@ class ArchDao
     /**
      * Update the arch in the DB
      */
-    public function update(Arch &$arch)
+    public function update(Arch $arch)
     {
         $this->db->query("update Arch set
             name='".$this->db->escape($arch->getName())."
@@ -100,7 +100,7 @@ class ArchDao
     /**
      * Delete the arch from the DB
      */
-    public function delete(Arch &$arch)
+    public function delete(Arch $arch)
     {
         $this->db->query("delete from Arch where id=".$this->db->escape($arch->getId()));
     }

--- a/src/dao/CveDao.php
+++ b/src/dao/CveDao.php
@@ -35,12 +35,12 @@ class CveDao
 {
     private $db;
 
-    public function __construct(DbManager &$dbManager)
+    public function __construct(DbManager $dbManager)
     {
         $this->db = $dbManager;
     }
 
-    public function create(Cve &$cve)
+    public function create(Cve $cve)
     {
         $sql = "insert into Cve set
             name='" . $this->db->escape($cve->getName()) . "'";

--- a/src/dao/CveDefDao.php
+++ b/src/dao/CveDefDao.php
@@ -35,12 +35,12 @@ class CveDefDao
 {
     private $db;
 
-    public function __construct(DbManager &$dbManager)
+    public function __construct(DbManager $dbManager)
     {
         $this->db = $dbManager;
     }
 
-    public function create(CveDef &$cveDef)
+    public function create(CveDef $cveDef)
     {
         $sql = "insert into CveDef set
             definitionId='".$this->db->escape($cveDef->getDefinitionId())."',

--- a/src/dao/CveExceptionDao.php
+++ b/src/dao/CveExceptionDao.php
@@ -35,12 +35,12 @@ class CveExceptionDao
 {
     private $db;
 
-    public function __construct(DbManager &$dbManager)
+    public function __construct(DbManager $dbManager)
     {
         $this->db = $dbManager;
     }
 
-    public function create(CveException &$exception)
+    public function create(CveException $exception)
     {
         $this->db->query("insert into `CveException` set
             pkgId='" . $this->db->escape($exception->getPkgId()) . "',
@@ -112,7 +112,7 @@ class CveExceptionDao
         return $id;
     }
 
-    public function delete(CveException &$exception)
+    public function delete(CveException $exception)
     {
         $this->db->query("delete from CveException
             where id=" . $this->db->escape($exception->getId()));

--- a/src/dao/CveTagDao.php
+++ b/src/dao/CveTagDao.php
@@ -34,12 +34,12 @@ class CveTagDao
 {
     private $db;
 
-    public function __construct(DbManager &$dbManager)
+    public function __construct(DbManager $dbManager)
     {
         $this->db = $dbManager;
     }
 
-    public function create(CveTag &$cveTag)
+    public function create(CveTag $cveTag)
     {
         $sql = "insert into CveTag set
             cveName='" . $this->db->escape($cveTag->getCveName()) . "',
@@ -55,7 +55,7 @@ class CveTagDao
         $cveTag->setId($this->db->getLastInsertedId());
     }
 
-    public function update(CveTag &$cveTag)
+    public function update(CveTag $cveTag)
     {
         $sql = "update CveTag set
             cveName='" . $this->db->escape($cveTag->getCveName()) . "',

--- a/src/dao/DomainDao.php
+++ b/src/dao/DomainDao.php
@@ -34,12 +34,12 @@ class DomainDao
 {
     private $db;
 
-    public function __construct(DbManager &$dbManager)
+    public function __construct(DbManager $dbManager)
     {
         $this->db = $dbManager;
     }
 
-    public function create(Domain &$domain)
+    public function create(Domain $domain)
     {
         $this->db->query("insert into Domain set
             name='".$this->db->escape($domain->getName())."'");
@@ -83,14 +83,14 @@ class DomainDao
         return $this->db->queryToSingleValueMultiRow($sql);
     }
 
-    public function update(Domain &$domain)
+    public function update(Domain $domain)
     {
         $this->db->query("update Domain set
             name='".$this->db->escape($domain->getName())."
             where id=".$domain->getId());
     }
 
-    public function delete(Domain &$domain)
+    public function delete(Domain $domain)
     {
         $this->db->query("delete from Domain where id=".$domain->getId());
     }

--- a/src/dao/HostDao.php
+++ b/src/dao/HostDao.php
@@ -35,12 +35,12 @@ class HostDao
 {
     private $db;
 
-    public function __construct(DbManager &$dbManager)
+    public function __construct(DbManager $dbManager)
     {
         $this->db = $dbManager;
     }
 
-    public function create(Host &$host)
+    public function create(Host $host)
     {
         if ($host == null) {
             Utils::log(LOG_ERR, "Exception", __FILE__, __LINE__);
@@ -279,7 +279,7 @@ class HostDao
         return $this->db->queryToSingleValueMultiRow($sql);
     }
 
-    public function update(Host &$host)
+    public function update(Host $host)
     {
         if ($host == null || $host->getId() == -1) {
             Utils::log(LOG_ERR, "Exception", __FILE__, __LINE__);

--- a/src/dao/HostGroupDao.php
+++ b/src/dao/HostGroupDao.php
@@ -35,12 +35,12 @@ class HostGroupDao
 {
     private $db;
 
-    public function __construct(DbManager &$dbManager)
+    public function __construct(DbManager $dbManager)
     {
         $this->db = $dbManager;
     }
 
-    public function create(HostGroup &$hostGroup)
+    public function create(HostGroup $hostGroup)
     {
         $sql = "insert into HostGroup set
             name='".$this->db->escape($hostGroup->getName())."',
@@ -53,7 +53,7 @@ class HostGroupDao
         $hostGroup->setId($this->db->getLastInsertedId());
     }
 
-    public function update(HostGroup &$hostGroup)
+    public function update(HostGroup $hostGroup)
     {
         $sql = "update HostGroup set
             name='".$this->db->escape($hostGroup->getName())."',

--- a/src/dao/OsDao.php
+++ b/src/dao/OsDao.php
@@ -35,12 +35,12 @@ class OsDao
 {
     private $db;
 
-    public function __construct(DbManager &$dbManager)
+    public function __construct(DbManager $dbManager)
     {
         $this->db = $dbManager;
     }
 
-    public function create(Os &$os)
+    public function create(Os $os)
     {
         $sql = "insert into Os set
             name='" . $this->db->escape($os->getName()) . "'";

--- a/src/dao/OsGroupDao.php
+++ b/src/dao/OsGroupDao.php
@@ -35,12 +35,12 @@ class OsGroupDao
 {
     private $db;
 
-    public function __construct(DbManager &$dbManager)
+    public function __construct(DbManager $dbManager)
     {
         $this->db = $dbManager;
     }
 
-    public function create(OsGroup &$osGroup)
+    public function create(OsGroup $osGroup)
     {
         $sql = "insert into OsGroup set
             name='" . $this->db->escape($osGroup->getName()) . "'";

--- a/src/dao/PkgDao.php
+++ b/src/dao/PkgDao.php
@@ -35,7 +35,7 @@ class PkgDao
 {
     private $db;
 
-    public function __construct(DbManager &$dbManager)
+    public function __construct(DbManager $dbManager)
     {
         $this->db = $dbManager;
     }
@@ -43,7 +43,7 @@ class PkgDao
     /**
      * Stores the pkg in the DB
      */
-    public function create(Pkg &$pkg)
+    public function create(Pkg $pkg)
     {
         $this->db->query("insert into Pkg set
             name='" . $this->db->escape($pkg->getName()) . "',
@@ -144,7 +144,7 @@ class PkgDao
     /**
      * Update the pkg in the DB
      */
-    public function update(Pkg &$pkg)
+    public function update(Pkg $pkg)
     {
         $this->db->query("update Pkg set
             name='" . $this->db->escape($pkg->getName()) . "',

--- a/src/dao/PkgTypeDao.php
+++ b/src/dao/PkgTypeDao.php
@@ -34,12 +34,12 @@ class PkgTypeDao
 {
     private $db;
 
-    public function __construct(DbManager &$dbManager)
+    public function __construct(DbManager $dbManager)
     {
         $this->db = $dbManager;
     }
 
-    public function create(PkgType &$pkgType)
+    public function create(PkgType $pkgType)
     {
         $sql = "insert into PkgType set
             name='" . $this->db->escape($pkgType->getName()) . "'";

--- a/src/dao/ReportDao.php
+++ b/src/dao/ReportDao.php
@@ -34,12 +34,12 @@ class ReportDao
 {
     private $db;
 
-    public function __construct(DbManager &$dbManager)
+    public function __construct(DbManager $dbManager)
     {
         $this->db = $dbManager;
     }
 
-    public function create(Report &$report)
+    public function create(Report $report)
     {
         $this->db->query("insert into Report set
             processedOn='".$this->db->escape(date('Y-m-d H:i:s', $report->getProcessedOn()))."',
@@ -81,7 +81,7 @@ class ReportDao
         return $id;
     }
 
-    public function update(Report &$report)
+    public function update(Report $report)
     {
         $this->db->query("update Report set
             processedOn='".$this->db->escape(date('Y-m-d H:i:s', $report->getProcessedOn()))."',
@@ -98,7 +98,7 @@ class ReportDao
             where id=".$report->getId());
     }
 
-    public function delete(Report &$report)
+    public function delete(Report $report)
     {
         $this->db->query("delete from Report where id=".$report->getId());
     }

--- a/src/dao/StatDao.php
+++ b/src/dao/StatDao.php
@@ -34,7 +34,7 @@ class StatDao
 {
     private $db;
 
-    public function __construct(DbManager &$dbManager)
+    public function __construct(DbManager $dbManager)
     {
         $this->db = $dbManager;
     }
@@ -42,7 +42,7 @@ class StatDao
     /**
      * Stores the stat in the DB
      */
-    public function create(Stat &$stat)
+    public function create(Stat $stat)
     {
         $this->db->query("insert into Stat set
             name='".$this->db->escape($stat->getName())."',
@@ -69,7 +69,7 @@ class StatDao
     /**
      * Update the stat in the DB
      */
-    public function update(Stat &$stat)
+    public function update(Stat $stat)
     {
         $this->db->query("update Stat set value=".$this->db->escape($stat->getValue())."
             where name='".$this->db->escape($stat->getName())."'");

--- a/src/dao/UserDao.php
+++ b/src/dao/UserDao.php
@@ -34,12 +34,12 @@ class UserDao
 {
     private $db;
 
-    public function __construct(DbManager &$dbManager)
+    public function __construct(DbManager $dbManager)
     {
         $this->db = $dbManager;
     }
 
-    public function create(User &$user)
+    public function create(User $user)
     {
         $sql = "insert into User set
             uid='".$this->db->escape($user->getUid())."',
@@ -77,7 +77,7 @@ class UserDao
         return $this->db->queryToSingleValueMultiRow($sql);
     }
 
-    public function update(User &$user)
+    public function update(User $user)
     {
         $sql = "update User set 
             uid='".$this->db->escape($user->getUid())."',

--- a/src/dao/VdsSourceDao.php
+++ b/src/dao/VdsSourceDao.php
@@ -34,7 +34,7 @@ class VdsSourceDao
 {
     private $db;
 
-    public function __construct(DbManager &$dbManager)
+    public function __construct(DbManager $dbManager)
     {
         $this->db = $dbManager;
     }
@@ -42,7 +42,7 @@ class VdsSourceDao
     /**
      * Stores the vdsSource in the DB
      */
-    public function create(VdsSource &$vdsSource)
+    public function create(VdsSource $vdsSource)
     {
         $this->db->query("insert into VdsSource set
             name='".$this->db->escape($vdsSource->getName())."',
@@ -55,7 +55,7 @@ class VdsSourceDao
     /**
      * Get the vdsSource by its ID
      */
-    public function getById($id, Pakiti &$pakiti)
+    public function getById($id, Pakiti $pakiti)
     {
         if (!is_numeric($id)) {
             return null;
@@ -66,7 +66,7 @@ class VdsSourceDao
     /**
      * Get the vdsSource by its name
      */
-    public function getByName($name, Pakiti &$pakiti)
+    public function getByName($name, Pakiti $pakiti)
     {
         return $this->getBy($name, "name", $pakiti);
     }
@@ -99,7 +99,7 @@ class VdsSourceDao
     /**
      * Update the vdsSource in the DB
      */
-    public function update(VdsSource &$vdsSource)
+    public function update(VdsSource $vdsSource)
     {
         $this->db->query("update VdsSource set
             name='".$this->db->escape($vdsSource->getName()).",
@@ -110,7 +110,7 @@ class VdsSourceDao
     /**
      * Delete the vdsSource from the DB
      */
-    public function delete(VdsSource &$vdsSource)
+    public function delete(VdsSource $vdsSource)
     {
         $this->db->query("delete from VdsSource where id=".$this->db->escape($vdsSource->getId()));
     }
@@ -118,7 +118,7 @@ class VdsSourceDao
     /**
      * We can get the data by ID or name
      */
-    protected function getBy($value, $type, Pakiti &$pakiti)
+    protected function getBy($value, $type, Pakiti $pakiti)
     {
         $where = "";
         if ($type == "id") {

--- a/src/dao/VdsSubSourceDao.php
+++ b/src/dao/VdsSubSourceDao.php
@@ -34,14 +34,14 @@ class VdsSubSourceDao
 {
     private $db;
 
-    public function __construct(DbManager &$dbManager) {
+    public function __construct(DbManager $dbManager) {
         $this->db = $dbManager;
     }
 
     /**
      * Stores the vdsSubSource in the DB
      */
-    public function create(VdsSubSourceDao &$vdsSubSource) {
+    public function create(VdsSubSourceDao $vdsSubSource) {
         $this->db->query("insert into VdsSubSource set
             name='".$this->db->escape($vdsSubSource->getName())."',
             type='".$this->db->escape($vdsSubSource->getType())."',

--- a/src/dao/VulnerabilityDao.php
+++ b/src/dao/VulnerabilityDao.php
@@ -35,7 +35,7 @@ class VulnerabilityDao
 {
     private $db;
 
-    public function __construct(DbManager &$dbManager)
+    public function __construct(DbManager $dbManager)
     {
         $this->db = $dbManager;
     }
@@ -43,7 +43,7 @@ class VulnerabilityDao
     /**
      * Stores the vulnerability in the DB
      */
-    public function create(Vulnerability &$vulnerability)
+    public function create(Vulnerability $vulnerability)
     {
         $this->db->query("insert into Vulnerability set
             operator='" . $vulnerability->getOperator() . "',
@@ -61,7 +61,7 @@ class VulnerabilityDao
     /**
      * Stores multiple vulnerabilities, using insert ignore to avoid errors during duplicates
      */
-    public function createMultiple(&$vulnerabilities)
+    public function createMultiple($vulnerabilities)
     {
         # If vulnerabilities is not an array, then quit
         if (!is_array($vulnerabilities)) {

--- a/src/managers/ArchsManager.php
+++ b/src/managers/ArchsManager.php
@@ -36,7 +36,7 @@ class ArchsManager extends DefaultManager
      * Create if not exist, else set id
      * @return false if already exist
      */
-    public function storeArch(Arch &$arch)
+    public function storeArch(Arch $arch)
     {
         Utils::log(LOG_DEBUG, "Storing the arch", __FILE__, __LINE__);
         if ($arch == null) {

--- a/src/managers/CveDefsManager.php
+++ b/src/managers/CveDefsManager.php
@@ -37,7 +37,7 @@ class CveDefsManager extends DefaultManager
      * Create if not exist, else set id
      * @return false if already exist
      */
-    public function storeCveDef(CveDef &$cveDef)
+    public function storeCveDef(CveDef $cveDef)
     {
         Utils::log(LOG_DEBUG, "Storing the CveDef", __FILE__, __LINE__);
         if ($cveDef == null) {

--- a/src/managers/CveExceptionsManager.php
+++ b/src/managers/CveExceptionsManager.php
@@ -36,7 +36,7 @@ class CveExceptionsManager extends DefaultManager
      * Create if not exist, else set id
      * @return false if already exist
      */
-    public function storeCveException(CveException &$cveException)
+    public function storeCveException(CveException $cveException)
     {
         Utils::log(LOG_DEBUG, "Storing the CveException", __FILE__, __LINE__);
         if ($cveException == null) {

--- a/src/managers/CveTagsManager.php
+++ b/src/managers/CveTagsManager.php
@@ -36,7 +36,7 @@ class CveTagsManager extends DefaultManager
      * Create if not exist, else set id
      * @return false if already exist
      */
-    public function storeCveTag(CveTag &$cveTag)
+    public function storeCveTag(CveTag $cveTag)
     {
         Utils::log(LOG_DEBUG, "Storing cveTag " . $cveTag->getCveName(), __FILE__, __LINE__);
         if ($cveTag == null) {

--- a/src/managers/CvesManager.php
+++ b/src/managers/CvesManager.php
@@ -36,7 +36,7 @@ class CvesManager extends DefaultManager
      * Create if not exist, else set id
      * @return false if already exist
      */
-    public function storeCve(Cve &$cve)
+    public function storeCve(Cve $cve)
     {
         Utils::log(LOG_DEBUG, "Storing the Cve", __FILE__, __LINE__);
         if ($cve == null) {

--- a/src/managers/DefaultManager.php
+++ b/src/managers/DefaultManager.php
@@ -34,9 +34,9 @@ class DefaultManager
 {
     private $_pakiti;
 
-    public function __construct(Pakiti &$pakiti)
+    public function __construct(Pakiti $pakiti)
     {
-        $this->_pakiti =& $pakiti;
+        $this->_pakiti = $pakiti;
     }
 
     public function getPakiti()

--- a/src/managers/DomainsManager.php
+++ b/src/managers/DomainsManager.php
@@ -36,7 +36,7 @@ class DomainsManager extends DefaultManager
     * Create if not exist, else set id
     * @return false if already exist
     */
-    public function storeDomain(Domain &$domain)
+    public function storeDomain(Domain $domain)
     {
         Utils::log(LOG_DEBUG, "Storing the domain", __FILE__, __LINE__);
         if ($domain == null) {

--- a/src/managers/HostGroupsManager.php
+++ b/src/managers/HostGroupsManager.php
@@ -37,7 +37,7 @@ class HostGroupsManager extends DefaultManager
      * Create if not exist, else set id
      * @return false if already exist
      */
-    public function storeHostGroup(HostGroup &$hostGroup)
+    public function storeHostGroup(HostGroup $hostGroup)
     {
         Utils::log(LOG_DEBUG, "Storing the hostGroup", __FILE__, __LINE__);
         if ($hostGroup == null) {
@@ -70,7 +70,7 @@ class HostGroupsManager extends DefaultManager
         return $this->getPakiti()->getDao("HostGroup")->getIdByName($name);
     }
 
-    public function getHostGroupsByHost(Host &$host)
+    public function getHostGroupsByHost(Host $host)
     {
         Utils::log(LOG_DEBUG, "Getting host groups by name [host={$host->getHostname()}]", __FILE__, __LINE__);
         $dao = $this->getPakiti()->getDao("HostGroup");

--- a/src/managers/HostsManager.php
+++ b/src/managers/HostsManager.php
@@ -37,7 +37,7 @@ class HostsManager extends DefaultManager
      * Create if not exist, else update and set id
      * @return false if already exist
      */
-    public function storeHost(Host &$host)
+    public function storeHost(Host $host)
     {
         Utils::log(LOG_DEBUG, "Storing the host", __FILE__, __LINE__);
         if ($host == null) {

--- a/src/managers/OsGroupsManager.php
+++ b/src/managers/OsGroupsManager.php
@@ -37,7 +37,7 @@ class OsGroupsManager extends DefaultManager
      * Create if not exist, else set id
      * @return false if already exist
      */
-    public function storeOsGroup(OsGroup &$osGroup)
+    public function storeOsGroup(OsGroup $osGroup)
     {
         Utils::log(LOG_DEBUG, "Storing the osGroup", __FILE__, __LINE__);
         if ($osGroup == null) {

--- a/src/managers/OsesManager.php
+++ b/src/managers/OsesManager.php
@@ -36,7 +36,7 @@ class OsesManager extends DefaultManager
      * Create if not exist, else set id
      * @return false if already exist
      */
-    public function storeOs(Os &$os)
+    public function storeOs(Os $os)
     {
         Utils::log(LOG_DEBUG, "Storing the os", __FILE__, __LINE__);
         if ($os == null) {

--- a/src/managers/PkgTypesManager.php
+++ b/src/managers/PkgTypesManager.php
@@ -36,7 +36,7 @@ class PkgTypesManager extends DefaultManager
      * Create if not exist, else set id
      * @return false if already exist
      */
-    public function storePkgType(PkgType &$pkgType)
+    public function storePkgType(PkgType $pkgType)
     {
         Utils::log(LOG_DEBUG, "Storing the pkgType", __FILE__, __LINE__);
         if ($pkgType == null) {

--- a/src/managers/PkgsManager.php
+++ b/src/managers/PkgsManager.php
@@ -37,7 +37,7 @@ class PkgsManager extends DefaultManager
      * Create if not exist, else set id
      * @return false if already exist
      */
-    public function storePkg(Pkg &$pkg)
+    public function storePkg(Pkg $pkg)
     {
         Utils::log(LOG_DEBUG, "Storing the pkg", __FILE__, __LINE__);
         if ($pkg == null) {

--- a/src/managers/ReportsManager.php
+++ b/src/managers/ReportsManager.php
@@ -78,7 +78,7 @@ class ReportsManager extends DefaultManager
     /*
      * Stores the report in the DB
      */
-    public function createReport(Report &$report, Host &$host)
+    public function createReport(Report $report, Host $host)
     {
         if ($host == null || $host->getId() == -1) {
             Utils::log(LOG_ERR, "Exception", __FILE__, __LINE__);
@@ -116,7 +116,7 @@ class ReportsManager extends DefaultManager
     /**
      * Retrieve both hashes for the report header and list of pkgs
      */
-    public function getLastReportHashes(Host &$host)
+    public function getLastReportHashes(Host $host)
     {
         if ($host == null || $host->getId() == -1) {
             Utils::log(LOG_ERR, "Exception", __FILE__, __LINE__);

--- a/src/managers/UsersManager.php
+++ b/src/managers/UsersManager.php
@@ -36,7 +36,7 @@ class UsersManager extends DefaultManager
      * Create if not exist, else update and set id
      * @return false if already exist
      */
-    public function storeUser(User &$user)
+    public function storeUser(User $user)
     {
         Utils::log(LOG_DEBUG, "Storing user", __FILE__, __LINE__);
         if ($user == null) {

--- a/src/managers/VulnerabilitiesManager.php
+++ b/src/managers/VulnerabilitiesManager.php
@@ -299,7 +299,7 @@ class VulnerabilitiesManager extends DefaultManager
         return $ver;
     }
 
-    public function storeVulnerabilities(&$vulnerabilities)
+    public function storeVulnerabilities($vulnerabilities)
     {
         return $this->getPakiti()->getDao("Vulnerability")->createMultiple($vulnerabilities);
     }

--- a/src/modules/cli/vds.php
+++ b/src/modules/cli/vds.php
@@ -65,7 +65,7 @@ switch ($cmd) {
     case "listSources":
         print "Registered VDS sources:\n";
         $sources = $vds->getSources();
-        foreach ($sources as &$source) {
+        foreach ($sources as $source) {
             print $source->getId()." ".$source->getName()."\n";
         }
         break;
@@ -77,11 +77,11 @@ switch ($cmd) {
         }
         $sourceId = $opt["sourceId"];
         
-        $source =& $vds->getSourceById($sourceId);
+        $source = $vds->getSourceById($sourceId);
         print "Registered VDS subsources for VDS source {$source->getName()}:\n";
         $subSources = $source->getSubSources();
         
-        foreach ($subSources as &$subSource) {
+        foreach ($subSources as $subSource) {
             print $subSource->getId()." ".$subSource->getName()."\n";
         }
         break;
@@ -93,9 +93,9 @@ switch ($cmd) {
         }
         $sourceId = $opt["sourceId"];
 
-        $source =& $vds->getSourceById($sourceId);
+        $source = $vds->getSourceById($sourceId);
         $subSources = $source->getSubSources();
-        foreach ($subSources as &$subSource) {
+        foreach ($subSources as $subSource) {
             $subSourceDefs = $subSource->getSubSourceDefs();
             foreach ($subSourceDefs as $subSourceDef) {
                 print "SubSource: {$subSource->getName()} - Id: {$subSourceDef->getId()}, Name: {$subSourceDef->getName()}, URI: {$subSourceDef->getUri()}\n";
@@ -114,8 +114,8 @@ switch ($cmd) {
         $defName = $opt["defName"];
         $defUri = $opt["defUri"];
 
-        $source =& $vds->getSourceById($sourceId);
-        $subSource =& $source->getSubSourceById($subSourceId);
+        $source = $vds->getSourceById($sourceId);
+        $subSource = $source->getSubSourceById($subSourceId);
         
         print "Adding subsource definition for the subsource ".$subSource->getName()."\n";
 
@@ -136,8 +136,8 @@ switch ($cmd) {
         $sourceId = $opt["sourceId"];
         $subSourceId = $opt["subSourceId"];
 
-        $source =& $vds->getSourceById($sourceId);
-        $subSource =& $source->getSubSourceById($subSourceId);
+        $source = $vds->getSourceById($sourceId);
+        $subSource = $source->getSubSourceById($subSourceId);
 
         $subSourceDefId = $opt["subSourceDefId"];
 
@@ -154,7 +154,7 @@ switch ($cmd) {
             die("--sourceId must be specified\n");
         }
         $sourceId = $opt["sourceId"];
-        $source =& $vds->getSourceById($sourceId);
+        $source = $vds->getSourceById($sourceId);
         foreach ($source->getSubSources() as $subSource) {
             $subSource->retrieveDefinitions();
         }

--- a/src/modules/feeder/FeederModule.php
+++ b/src/modules/feeder/FeederModule.php
@@ -51,7 +51,7 @@ class FeederModule extends DefaultModule
     private $_report_tag;
     private $_report_pkgs;
 
-    public function __construct(Pakiti &$pakiti)
+    public function __construct(Pakiti $pakiti)
     {
         parent::__construct($pakiti);
 
@@ -633,7 +633,7 @@ class FeederModule extends DefaultModule
         }
 
         $newPkgs = array();
-        foreach ($this->_pkgs as &$pkg) {
+        foreach ($this->_pkgs as $pkg) {
             # Check if pkg is already in installed pkgs
             if (array_key_exists($pkg->getName(), $installedPkgsArray)) {
                 foreach ($installedPkgsArray[$pkg->getName()] as $key => $installedPkg) {
@@ -778,7 +778,7 @@ class FeederModule extends DefaultModule
                 }
 
                 $found = false;
-                foreach (Config::$IGNORE_PACKAGES_PATTERNS as &$pkgNamePattern) {
+                foreach (Config::$IGNORE_PACKAGES_PATTERNS as $pkgNamePattern) {
                     if (preg_match("/$pkgNamePattern/", $pkgName) == 1) {
                         $found = true;
                         break;
@@ -930,7 +930,7 @@ class FeederModule extends DefaultModule
     protected function array_compare_recursive($array1, $array2)
     {
         $diff = array();
-        foreach ($array1 as $key => &$value) {
+        foreach ($array1 as $key => $value) {
             if (!array_key_exists($key, $array2)) {
                 $diff[$key] = $value;
             } elseif (is_array($value)) {

--- a/src/modules/gui/Html.php
+++ b/src/modules/gui/Html.php
@@ -51,7 +51,7 @@ class HTMLModule extends DefaultModule
 </body></html>
 ";
 
-    public function __construct(&$pakiti)
+    public function __construct($pakiti)
     {
         parent::__construct($pakiti);
 

--- a/src/modules/vds/VdsModule.php
+++ b/src/modules/vds/VdsModule.php
@@ -38,7 +38,7 @@ class VdsModule extends DefaultModule
     private $_sources;
     private $_pakiti;
 
-    public function __construct(Pakiti &$pakiti)
+    public function __construct(Pakiti $pakiti)
     {
         parent::__construct($pakiti);
         $this->_pakiti = $pakiti;
@@ -53,7 +53,7 @@ class VdsModule extends DefaultModule
     public function synchronize()
     {
         Utils::log(LOG_DEBUG, "Synchronizing VDS", __FILE__, __LINE__);
-        foreach ($this->_sources as &$source) {
+        foreach ($this->_sources as $source) {
             $vulnerabilities = $source->retrieveVulnerabilities();
             if ($vulnerabilities) {
                 $this->_pakiti->getManager("VulnerabilitiesManager")->storeVulnerabilities($vulnerabilities);
@@ -77,7 +77,7 @@ class VdsModule extends DefaultModule
     {
         Utils::log(LOG_DEBUG, "Getting VDS source by id [id=$id]", __FILE__, __LINE__);
         # We have to provide also Pakiti object, because constructor of the VDS source requires id
-        foreach ($this->_sources as &$source) {
+        foreach ($this->_sources as $source) {
             if ($source->getId() == $id) {
                 return $source;
             }
@@ -143,7 +143,7 @@ class VdsModule extends DefaultModule
      * Register the VDS source, but firstly check if the source hasn't been already registered. 
      * Enclose the operation with the transaction.
      */
-    protected function registerSource(ISource &$source)
+    protected function registerSource(ISource $source)
     {
         if ($source == null) {
             Utils::log(LOG_ERR, "Exception", __FILE__, __LINE__);
@@ -164,7 +164,7 @@ class VdsModule extends DefaultModule
     /**
      * Check if the source has been registered.
      */
-    protected function isSourceRegistered(ISource &$source)
+    protected function isSourceRegistered(ISource $source)
     {
         if ($source == null) {
             Utils::log(LOG_ERR, "Exception", __FILE__, __LINE__);

--- a/src/modules/vds/include/ISubSource.php
+++ b/src/modules/vds/include/ISubSource.php
@@ -48,7 +48,7 @@ interface ISubSource
 
     public function getSubSourceDefs();
 
-    public function addSubSourceDef(ISubSourceDef &$subSourceDef);
+    public function addSubSourceDef(ISubSourceDef $subSourceDef);
 
-    public function removeSubSourceDef(ISubSourceDef &$subSourceDef);
+    public function removeSubSourceDef(ISubSourceDef $subSourceDef);
 }

--- a/src/modules/vds/lib/Source.php
+++ b/src/modules/vds/lib/Source.php
@@ -35,9 +35,9 @@ class Source extends VdsSource
     private $_pakiti;
     private $_subSources;
 
-    public function __construct(Pakiti &$pakiti)
+    public function __construct(Pakiti $pakiti)
     {
-        $this->_pakiti =& $pakiti;
+        $this->_pakiti = $pakiti;
         $this->_subSources = array();
     }
 
@@ -70,7 +70,7 @@ class Source extends VdsSource
     public function getSubSourceById($id)
     {
         Utils::log(LOG_DEBUG, "Getting subsource by ID [id=$id]", __FILE__, __LINE__);
-        foreach ($this->_subSources as &$subSource) {
+        foreach ($this->_subSources as $subSource) {
             if ($subSource->getId() == $id) {
                 return $subSource;
             }

--- a/src/modules/vds/lib/SubSource.php
+++ b/src/modules/vds/lib/SubSource.php
@@ -39,10 +39,10 @@ class SubSource
     private $_pakiti;
     private $_db;
 
-    public function __construct(Pakiti &$pakiti)
+    public function __construct(Pakiti $pakiti)
     {
-        $this->_pakiti =& $pakiti;
-        $this->_db =& $pakiti->getManager("DbManager");
+        $this->_pakiti = $pakiti;
+        $this->_db = $pakiti->getManager("DbManager");
         $this->_subSourceDefs = array();
     }
 
@@ -80,7 +80,7 @@ class SubSource
         return $this->_db->queryObjects($sql, "SubSourceDef");
     }
 
-    public function addSubSourceDef(ISubSourceDef &$subSourceDef)
+    public function addSubSourceDef(ISubSourceDef $subSourceDef)
     {
         # Check if the subSourceDef already exists
         if (($id = $this->getBy($subSourceDef->getName(), "name") == null)) {
@@ -106,7 +106,7 @@ class SubSource
         return md5($this->getName() . $string);
     }
 
-    public function removeSubSourceDef(ISubSourceDef &$subSourceDef)
+    public function removeSubSourceDef(ISubSourceDef $subSourceDef)
     {
         $this->_db->query("delete from VdsSubSourceDef where id=".$this->_db->escape($subSourceDef->getId()));
     }
@@ -114,7 +114,7 @@ class SubSource
     /**
      * Update the SubSourceDef in the DB
      */
-    public function updateSubSourceDef(ISubSourceDef &$subSourceDef)
+    public function updateSubSourceDef(ISubSourceDef $subSourceDef)
     {
         $this->_db->query("update VdsSubSourceDef set
             name='".$this->_db->escape($subSourceDef->getName()).",
@@ -125,14 +125,14 @@ class SubSource
             where id=".$this->_db->escape($subSourceDef->getId()));
     }
 
-    public function getLastSubSourceDefHash(ISubSourceDef &$subSourceDef)
+    public function getLastSubSourceDefHash(ISubSourceDef $subSourceDef)
     {
         $row = $this->_db->queryToSingleRow("select lastSubSourceDefHash from VdsSubSourceDef
             where id=" . $this->_db->escape($subSourceDef->getId()));
         return $row["lastSubSourceDefHash"];
     }
 
-    protected function isSubSourceDefContainsNewData(ISubSourceDef &$subSourceDef, $currentSubSourceHash)
+    protected function isSubSourceDefContainsNewData(ISubSourceDef $subSourceDef, $currentSubSourceHash)
     {
         $lastSubSourceHash = $this->getLastSubSourceDefHash($subSourceDef);
         if ($lastSubSourceHash != null && $lastSubSourceHash == $currentSubSourceHash) {
@@ -149,7 +149,7 @@ class SubSource
      * @param ISubSourceDef $subSourceDef
      * @param $subSourceDefHash
      */
-    public function updateLastSubSourceDefHash(ISubSourceDef &$subSourceDef, $subSourceDefHash)
+    public function updateLastSubSourceDefHash(ISubSourceDef $subSourceDef, $subSourceDefHash)
     {
         $this->_db->query("update VdsSubSourceDef set
             lastSubSourceDefHash='" . $this->_db->escape($subSourceDefHash) . "'
@@ -159,7 +159,7 @@ class SubSource
     /**
      * Enable the sourceDef
      */
-    public function enableSubSourceDef(ISubSourceDef &$subSourceDef)
+    public function enableSubSourceDef(ISubSourceDef $subSourceDef)
     {
         $this->_db->query("update VdsSubSourceDef set enabled=".Constants::$ENABLED." where id=".$this->_db->escape($subSourceDef->getId()));
     }
@@ -167,12 +167,12 @@ class SubSource
     /**
      * Disable the sourceDef
      */
-    public function disableSubSourceDef(ISubSourceDef &$subSourceDef)
+    public function disableSubSourceDef(ISubSourceDef $subSourceDef)
     {
         $this->_db->query("update VdsSubSourceDef set enabled=".Constants::$DISABLED." where id=".$this->_db->escape($subSourceDef->getId()));
     }
 
-    public function updateSubSourceLastChecked(ISubSourceDef &$subSourceDef)
+    public function updateSubSourceLastChecked(ISubSourceDef $subSourceDef)
     {
         $this->_db->query("update VdsSubSourceDef set lastChecked=now() where id=".$this->_db->escape($subSourceDef->getId()));
     }
@@ -180,7 +180,7 @@ class SubSource
     /**
      * Assign OS for the subSourceDef
      */
-    public function assignOsToSubSourceDef(ISubSourceDef &$subSourceDef, Os $os)
+    public function assignOsToSubSourceDef(ISubSourceDef $subSourceDef, Os $os)
     {
         $this->_db->query("insert into VdsSourceDefOs (vdsSubSourceId, osId) values (" . $this->_db->escape($subSourceDef->getId()) .",". $this->_db->escape($os->getId()) . ")");
     }
@@ -188,7 +188,7 @@ class SubSource
     /**
      * Remove link between OS and subSourceDef
      */
-    public function removeOsFromSubSourceDef(ISubSourceDef &$subSourceDef, Os $os)
+    public function removeOsFromSubSourceDef(ISubSourceDef $subSourceDef, Os $os)
     {
         $this->_db->query("delete from VdsSourceDefOs
             where vdsSubSourceId=" . $this->_db->escape($subSourceDef->getId()) . "

--- a/src/modules/vds/sources/CveSource.php
+++ b/src/modules/vds/sources/CveSource.php
@@ -40,11 +40,11 @@ class CveSource extends Source implements ISource
     /**
      * Load all types of CVE sources
      */
-    public function __construct(Pakiti &$pakiti)
+    public function __construct(Pakiti $pakiti)
     {
         parent::__construct($pakiti);
 
-        $this->_pakiti =& $pakiti;
+        $this->_pakiti = $pakiti;
         $this->setName(CveSource::$NAME);
     }
 

--- a/src/modules/vds/sources/CveSubSources/OvalLocal.php
+++ b/src/modules/vds/sources/CveSubSources/OvalLocal.php
@@ -114,7 +114,7 @@ class OvalLocal extends SubSource implements ISubSource
     }
 
     # Process each criteria, this function must be duplicated because PHP removed call by reference. processCriteriasWithReference requires os and package to be passed as a reference
-    protected function processCriteriasWithReference(&$xpath, $criteriaElement, &$res, &$oses, &$packages)
+    protected function processCriteriasWithReference($xpath, $criteriaElement, &$res, &$oses, &$packages)
     {
         $operator = $criteriaElement->attributes->getNamedItem('operator')->nodeValue;
 
@@ -193,7 +193,7 @@ class OvalLocal extends SubSource implements ISubSource
         }
     }
 
-    protected function processCriterias(&$xpath, $criteriaElement, &$res, $oses, $packages)
+    protected function processCriterias($xpath, $criteriaElement, &$res, $oses, $packages)
     {
         $operator = $criteriaElement->attributes->getNamedItem('operator')->nodeValue;
 

--- a/src/modules/vds/sources/CveSubSources/OvalRedHat.php
+++ b/src/modules/vds/sources/CveSubSources/OvalRedHat.php
@@ -136,7 +136,7 @@ class OvalRedHat extends SubSource implements ISubSource
     /**
      * Get the operator from the XML element: AND/OR
      */
-    protected function getOperator(&$xElem)
+    protected function getOperator($xElem)
     {
         if ($xElem->item(0)->getAttribute('operator') == "AND") {
             return "and";
@@ -150,7 +150,7 @@ class OvalRedHat extends SubSource implements ISubSource
     /**
      * Extracts the RedHat release version (3, 4, 5, 6, ...)
      */
-    protected function getOsVersion(&$xElem)
+    protected function getOsVersion($xElem)
     {
         $rawOsVersion = $xElem->getAttribute('comment');
         # Parse the OS version from the string 'Red Hat Enterprise Linux 5 is installed'
@@ -165,7 +165,7 @@ class OvalRedHat extends SubSource implements ISubSource
      * Process list of the packages for each OS version.
      * Returns an array [osVersion] -> [pkgName => pkgVersion]*
      */
-    protected function processPkgsForOs(&$xElem)
+    protected function processPkgsForOs($xElem)
     {
         # Get the OS version from the childElement
         $childElement = $this->_xpath->query("./def:criterion", $xElem);
@@ -191,7 +191,7 @@ class OvalRedHat extends SubSource implements ISubSource
     }
 
     # Process each criteria, this function must be duplicated because PHP removed call by reference. processCriteriasWithReference requires os and package to be passed as a reference
-    protected function processCriteriasWithReference(&$xpath, $criteriaElement, &$res, &$os, &$package)
+    protected function processCriteriasWithReference($xpath, $criteriaElement, &$res, &$os, &$package)
     {
         $operator = $criteriaElement->attributes->getNamedItem('operator')->nodeValue;
 
@@ -260,7 +260,7 @@ class OvalRedHat extends SubSource implements ISubSource
         }
     }
 
-    protected function processCriterias(&$xpath, $criteriaElement, &$res, $os, $package)
+    protected function processCriterias($xpath, $criteriaElement, &$res, $os, $package)
     {
         $operator = $criteriaElement->attributes->getNamedItem('operator')->nodeValue;
 

--- a/src/modules/vds/sources/CveSubSources/OvalSUSE.php
+++ b/src/modules/vds/sources/CveSubSources/OvalSUSE.php
@@ -115,7 +115,7 @@ class OvalSUSE extends SubSource implements ISubSource
     }
    
     # Process each criteria, this function must be duplicated because PHP removed call by reference. processCriteriasWithReference requires os and package to be passed as a reference
-    protected function processCriteriasWithReference(&$xpath, $criteriaElement, &$res, &$os, &$packages)
+    protected function processCriteriasWithReference($xpath, $criteriaElement, &$res, &$os, &$packages)
     {
         $operator = $criteriaElement->attributes->getNamedItem('operator')->nodeValue;
 
@@ -190,7 +190,7 @@ class OvalSUSE extends SubSource implements ISubSource
         }
     }
 
-    protected function processCriterias(&$xpath, $criteriaElement, &$res, $os, $packages)
+    protected function processCriterias($xpath, $criteriaElement, &$res, $os, $packages)
     {
         $operator = $criteriaElement->attributes->getNamedItem('operator')->nodeValue;
 

--- a/src/modules/vds/sources/CveSubSources/OvalUbuntu.php
+++ b/src/modules/vds/sources/CveSubSources/OvalUbuntu.php
@@ -114,7 +114,7 @@ class OvalUbuntu extends SubSource implements ISubSource
     }
 
     # Process each criteria, this function must be duplicated because PHP removed call by reference. processCriteriasWithReference requires os and package to be passed as a reference
-    protected function processCriteriasWithReference(&$xpath, $criteriaElement, &$res, &$oses, &$packages)
+    protected function processCriteriasWithReference($xpath, $criteriaElement, &$res, &$oses, &$packages)
     {
         $operator = $criteriaElement->attributes->getNamedItem('operator');
         if (!empty($operator)) {
@@ -194,7 +194,7 @@ class OvalUbuntu extends SubSource implements ISubSource
         }
     }
 
-    protected function processCriterias(&$xpath, $criteriaElement, &$res, $oses, $packages)
+    protected function processCriterias($xpath, $criteriaElement, &$res, $oses, $packages)
     {
         $operator = $criteriaElement->attributes->getNamedItem('operator');
         if (!empty($operator)) {

--- a/src/modules/vds/sources/RepositoriesSource.php
+++ b/src/modules/vds/sources/RepositoriesSource.php
@@ -36,7 +36,7 @@ class RepositoriesSource extends Source implements ISource {
 	private static $NAME = "Repositories"; 
 	private $_pakiti;
   
-  public function __construct(Pakiti &$pakiti) {
+  public function __construct(Pakiti $pakiti) {
     parent::__construct($pakiti);
 
     $this->setName(RepositoriesSource::$NAME);


### PR DESCRIPTION
Remove passing Objects around by reference in function calls and in foreach loops. They are  unnecessary for objects and generate PHP Notices in PHP > 7.0.7

Only variables should be passed by reference
Only variables should be assigned by reference
https://wiki.php.net/rfc/reclassify_e_strict#only_variables_should_be_passed_by_reference