### PR TITLE
Handle bz2 compressed OVAL files

### DIFF
--- a/src/modules/vds/lib/SubSource.php
+++ b/src/modules/vds/lib/SubSource.php
@@ -215,9 +215,10 @@ class SubSource
             $finfo = new finfo(FILEINFO_MIME_TYPE);
             $mimetype = $finfo->buffer($contents);
             switch ($mimetype) {
-                case "text/xml":
+                case "text/plain": //Debian DSA
+                case "text/xml": // Uncompressed OVAL
                     break;
-                case "application/x-bzip2":
+                case "application/x-bzip2": //Compressed OVAL
                     $contents = bzdecompress($contents);
                     break;
                 default:

--- a/src/modules/vds/lib/SubSource.php
+++ b/src/modules/vds/lib/SubSource.php
@@ -220,6 +220,10 @@ class SubSource
                     break;
                 case "application/x-bzip2": //Compressed OVAL
                     $contents = bzdecompress($contents);
+                    if (is_int($contents)) {
+                        Utils::log(LOG_ERR, "Failed to bzdecompress data (errorno: %s) when reading definitions for %s", $contents, $subSourceDef->getUri());
+                        continue;
+                    }
                     break;
                 default:
                     Utils::log(LOG_ERR, "Unknown mimetype %s when reading definitions for %s", $mimetype, $subSourceDef->getUri());

--- a/src/modules/vds/lib/SubSource.php
+++ b/src/modules/vds/lib/SubSource.php
@@ -212,6 +212,19 @@ class SubSource
                 continue;
             }
 
+            $finfo = new finfo(FILEINFO_MIME_TYPE);
+            $mimetype = $finfo->buffer($contents);
+            switch ($mimetype) {
+                case "text/xml":
+                    break;
+                case "application/x-bzip2":
+                    $contents = bzdecompress($contents);
+                    break;
+                default:
+                    Utils::log(LOG_ERR, "Unknown mimetype %s when reading definitions for %s", $mimetype, $subSourceDef->getUri());
+                    continue;
+            }
+
             $currentSubSourceHash = $this->computeHash($contents);
             if (! $this->isSubSourceDefContainsNewData($subSourceDef, $currentSubSourceHash)) {
                 $this->updateSubSourceLastChecked($subSourceDef);


### PR DESCRIPTION
Ubuntu and Oracle OVAL files are distributed with bz2 compression. Detect compression and decompress file before import.