### PR TITLE
Fix deleting unused packages

### DIFF
--- a/src/modules/cli/deleteUnusedPackages.php
+++ b/src/modules/cli/deleteUnusedPackages.php
@@ -5,6 +5,6 @@ require(realpath(dirname(__FILE__)) . '/../../common/Loader.php');
 
 $pkgsIds = $pakiti->getManager("PkgsManager")->getUnusedPkgsIds();
 foreach ($pkgsIds as $pkgsId) {
-    $pakiti->getManager("PkgsManager")->deletePkg($pkgId);
+    $pakiti->getManager("PkgsManager")->deletePkg($pkgsId);
 }
 print "Number of deleted packages: " . count($pkgsIds) . "\n";


### PR DESCRIPTION
Simple fix missing letter "s" in loop to make deleting unused packages work.

Fixes #172 