### PR TITLE
Add application/xml mime type and fix related logging.

### DIFF
--- a/src/modules/vds/lib/SubSource.php
+++ b/src/modules/vds/lib/SubSource.php
@@ -217,6 +217,7 @@ class SubSource
             switch ($mimetype) {
                 case "text/plain": //Debian DSA
                 case "text/xml": // Uncompressed OVAL
+                case "application/xml": // Uncompressed OVAL
                     break;
                 case "application/x-bzip2": //Compressed OVAL
                     $contents = bzdecompress($contents);
@@ -226,7 +227,7 @@ class SubSource
                     }
                     break;
                 default:
-                    Utils::log(LOG_ERR, "Unknown mimetype %s when reading definitions for %s", $mimetype, $subSourceDef->getUri());
+                    Utils::log(LOG_ERR, "Unknown mimetype " . $mimetype . " when reading definitions for" . $subSourceDef->getUri());
                     continue;
             }
 


### PR DESCRIPTION
The application/xml mime type was reported by https://www.redhat.com/security/data/oval/com.redhat.rhsa-2019.xml (and earlier), though curl says text/xml, so maybe a library which is canonicalizing it?  In any case,  application/xml is a valid mime type which is more or less regarded as equivalent to text/xml.