### PR TITLE
Fixed parsing error on Ubuntu OVAL

### DIFF
--- a/src/modules/vds/sources/CveSubSources/OvalUbuntu.php
+++ b/src/modules/vds/sources/CveSubSources/OvalUbuntu.php
@@ -114,7 +114,7 @@ class OvalUbuntu extends SubSource implements ISubSource
                 $comment = $criterion->attributes->getNamedItem('comment')->nodeValue;
                 //print "Comment: $comment\n";
                 if (strpos($comment, "was vulnerable but has been fixed") !== false) {
-                    if (preg_match("/^The '(.*)' package in (.*) was vulnerable but has been fixed \(note: '([^-]*)-(.*)'\).$/", $comment, $values) === 1) {
+                    if (preg_match("/^(.*) package in (.*) was vulnerable but has been fixed \(note: '([^-]*)-(.*)'\).$/", $comment, $values) === 1) {
                         //array_push($oses, $values[2]);
                         $package = array();
                         $package['name'] = $values[1];
@@ -195,7 +195,7 @@ class OvalUbuntu extends SubSource implements ISubSource
                 $comment = $criterion->attributes->getNamedItem('comment')->nodeValue;
                 //print "Comment: $comment\n";
                 if (strpos($comment, "was vulnerable but has been fixed") !== false) {
-                    if (preg_match("/^The '(.*)' package in (.*) was vulnerable but has been fixed \(note: '([^-]*)-(.*)'\).$/", $comment, $values) === 1) {
+                    if (preg_match("/^(.*) package in (.*) was vulnerable but has been fixed \(note: '([^-]*)-(.*)'\).$/", $comment, $values) === 1) {
                         //array_push($oses, $values[2]);
                         $package = array();
                         $package['name'] = $values[1];


### PR DESCRIPTION
On new Ubuntu OVALs the "comment" field on the "criterion" changed in such a way that parsing was not being done correctly, resulting in an unpopulated database misleading us that no CVEs were found.

Example of new OVAL:
criterion test_ref="oval:com.ubuntu.bionic:tst:2017131340000010" comment="imagemagick package in bionic was vulnerable but has been fixed (note: '8:6.9.7.4+dfsg-16ubuntu6.2')."

Parsing was expecting it to be:
criterion test_ref="oval:com.ubuntu.bionic:tst:2017131340000010" comment="**The '** imagemagick **'** package in bionic was vulnerable but has been fixed (note: '8:6.9.7.4+dfsg-16ubuntu6.2')."

This pull request fixes CESNET/pakiti-server#170.