### PR TITLE
add jessie and stretch as ignored debian versions

### DIFF
--- a/src/common/DefaultConfig.php
+++ b/src/common/DefaultConfig.php
@@ -124,7 +124,7 @@ class DefaultConfig
     # Debian publishes vulnerabilities at a single URL, referring to all distributions. Setting this
     # directive makes the processing a bit more efficient and helps avoid errors when indices for the
     # older distributions are not available.
-    public static $DEBIAN_IGNORED_VERSIONS = [ "wheezy", "squeeze", "lenny", "etch", "sarge", "woody" ];
+    public static $DEBIAN_IGNORED_VERSIONS = [ "stretch", "jessie", "wheezy", "squeeze", "lenny", "etch", "sarge", "woody" ];
     # Endpoint to get the Debian Source indices
     public static $DEBIAN_REPOSITORY = "http://ftp.debian.org/debian";
 


### PR DESCRIPTION
As Debian Jessie and Stretch are not LTS anymore, the packages are not reachables from http://ftp.debian.org/debian/dists/
On pakiti, when using the cron which synchronize the VDS we get a 404 error on it :

`root@XXXXX:~# php /var/www/pakiti/src/modules/cli/vds.php -c synchronize
PHP Warning:  file_get_contents(http://ftp.debian.org/debian/dists/stretch/non-free/source/Sources.gz): failed to open stream: HTTP request failed! HTTP/1.1 404 Not Found
 in /var/www/pakiti/src/common/Utils.php on line 145
PHP Fatal error:  Uncaught Exception: Error reading Debian Source indices: Error while getting contents (file_get_contents(http://ftp.debian.org/debian/dists/stretch/non-free/source/Sources.gz): failed to open stream: HTTP request failed! HTTP/1.1 404 Not Found
) in /var/www/pakiti/src/modules/vds/sources/CveSubSources/Debian.php:119
Stack trace:
#0 /var/www/pakiti/src/modules/vds/sources/CveSubSources/Debian.php(129): Debian->update_package_mapping('stretch')
#1 /var/www/pakiti/src/modules/vds/sources/CveSubSources/Debian.php(231): Debian->add_packages(Array, 'stretch', 'thunderbird', Array)
#2 /var/www/pakiti/src/modules/vds/lib/SubSource.php(223): Debian->processAdvisories('[14 May 2023] D...', '5')
#3 /var/www/pakiti/src/modules/vds/sources/CveSource.php(47): SubSource->retrieveVulnerabilities()
#4 /var/www/pakiti/src/modules/vds/VdsModule.php(30): CveSource->retrieveVulnerabilities()
#5 /var/www/pakiti/src/modules/cli/vds.php(138): VdsModule->synchronize()
#6 {main}
  thrown in /var/www/pakiti/src/modules/vds/sources/CveSubSources/Debian.php on line 119`

This PR disable those Debian distributions.
