### PR TITLE
Small code improvements

### DIFF
--- a/src/modules/api/cve.php
+++ b/src/modules/api/cve.php
@@ -28,7 +28,6 @@ switch ($type) {
         }
         break;
     case "xml":
-        print header("Content-Type: text/xml; charset=utf-8");
         header("Content-Type: text/xml; charset=utf-8");
         $xml = new SimpleXMLElement('<?xml version="1.0" encoding="UTF-8"?> <xml></xml>');
         foreach ($vulnerabilities as $vulnerability) {

--- a/src/modules/gui/Html.php
+++ b/src/modules/gui/Html.php
@@ -121,8 +121,8 @@ class HTMLModule extends DefaultModule
     public function checkPermission($source)
     {
         if (!$this->_acl->permission($source)) {
-            print($this->error403);
             header('HTTP/1.0 403 Forbidden');
+            print($this->error403);
             exit;
         }
     }


### PR DESCRIPTION
Just two small code improvements I found:
1) It's best practice in PHP to make all the header-calls before outputting the body of the page. Otherwise, those headers might not be applied.
2) The header-call returns void, so printing that is useless. Also, the line below set the same header again, so it's basically a duplicate line.