### PR TITLE
Fixed a regex mistake in the guessDomain function.

### DIFF
--- a/src/modules/feeder/FeederModule.php
+++ b/src/modules/feeder/FeederModule.php
@@ -856,7 +856,7 @@ class FeederModule extends DefaultModule
         }
 
         # Separate hostname from domain name
-        $domain = preg_replace('/^[\w-_]+\.(.*)$/', '\1', $hostname);
+        $domain = preg_replace('/^[\w\-]+\.(.*)$/', '\1', $hostname);
         
         # Check if domain ends with .local or .localdomain, these are not valid domains
         if (preg_match('/\.(local|localdomain)$/', $hostname) > 0) {


### PR DESCRIPTION
I'm seeing the following error in my logs:
PHP Warning:  preg_replace(): Compilation failed: invalid range in character class at offset 4 in /var/www/pakiti-server/src/modules/feeder/FeederModule.php on line 859

This is because in the regex /^[\w-_]+\.(.*)$/  the minus is trying to create a range between the \w and the underscore, which is not valid. The minus needs to be escaped.
And the underscore is redundant, because it's already included in the \w.