### PR TITLE
Fixed an incorrect string formatting, eating an error message.

### DIFF
--- a/src/modules/vds/lib/SubSource.php
+++ b/src/modules/vds/lib/SubSource.php
@@ -209,7 +209,7 @@ class SubSource
             try {
                 $contents = Utils::downloadContents($subSourceDef->getUri());
             } catch (Exception $e) {
-                Utils::log(LOG_ERR, "Error reading definitions for %s: %s", $subSourceDef->getUri(), $e->getMessage());
+                Utils::log(LOG_ERR, "Error reading definitions for ".$subSourceDef->getUri().": ".$e->getMessage(), __FILE__, __LINE__);
                 continue;
             }
 


### PR DESCRIPTION
Changed a Python-style string formatting into a PHP-style one. This was eating the formatting arguments, causing the resulting error message to be missing the actual error message.